### PR TITLE
Do not rely on empty bibcodes from datacite parser to track software records

### DIFF
--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -50,7 +50,9 @@ def store_citation(app, citation_change, content_type, raw_metadata, parsed_meta
 
 def get_citation_target_metadata(app, citation_change):
     """
-    If the citation target already exists in the database, return the metadata.
+    If the citation target already exists in the database, return the raw and
+    parsed metadata together with the status of the citation target in the
+    database.
     If not, return an empty dictionary.
     """
     citation_in_db = False
@@ -61,6 +63,7 @@ def get_citation_target_metadata(app, citation_change):
         if citation_target_in_db:
             metadata['raw'] = citation_target.raw_cited_metadata
             metadata['parsed'] = citation_target.parsed_cited_metadata
+            metadata['status'] = citation_target.status
     return metadata
 
 def get_citations_by_bibcode(app, bibcode):

--- a/ADSCitationCapture/doi.py
+++ b/ADSCitationCapture/doi.py
@@ -173,7 +173,7 @@ def _parse_metadata_zenodo_doi(raw_metadata):
         logger.exception("Failed parsing")
         return {}
     parsed_metadata['link_alive'] = True
-    is_software = parsed_metadata['doctype'].lower() == "software"
+    is_software = parsed_metadata.get('doctype', u'').lower() == "software"
 
     if is_software:
         zenodo_bibstem = "zndo"

--- a/ADSCitationCapture/tasks.py
+++ b/ADSCitationCapture/tasks.py
@@ -41,8 +41,8 @@ def task_process_new_citation(citation_change, force=False):
     citation_target_in_db = bool(metadata) # False if dict is empty
     raw_metadata = metadata.get('raw', None)
     parsed_metadata = metadata.get('parsed', None)
-    if parsed_metadata and parsed_metadata.get('bibcode') not in (None, ""):
-        status = "REGISTERED"
+    if citation_target_in_db:
+        status = metadata.get('status', 'DISCARDED') # "REGISTERED" if it is a software record
 
     if citation_change.content_type == adsmsg.CitationChangeContentType.doi \
         and citation_change.content not in ["", None]:
@@ -55,7 +55,8 @@ def task_process_new_citation(citation_change, force=False):
             raw_metadata = doi.fetch_metadata(app.conf['DOI_URL'], app.conf['DATACITE_URL'], citation_change.content)
             if raw_metadata:
                 parsed_metadata = doi.parse_metadata(raw_metadata)
-                if parsed_metadata.get('bibcode') not in (None, ""):
+                is_software = parsed_metadata.get('doctype', u'').lower() == "software"
+                if parsed_metadata.get('bibcode') not in (None, "") and is_software:
                     status = "REGISTERED"
     elif citation_change.content_type == adsmsg.CitationChangeContentType.pid \
         and citation_change.content not in ["", None]:

--- a/ADSCitationCapture/tests/test_base.py
+++ b/ADSCitationCapture/tests/test_base.py
@@ -47,5 +47,6 @@ class TestBase(unittest.TestCase):
                     'version_of': [],
                     'source': u'ZENODO',
                     'link_alive': True
-                }
+                },
+                'status': 'REGISTERED'
         }


### PR DESCRIPTION
The datacite metadata parser may recover a bibcode (e.g., from 'supplemented by') which has not been generated by citation capture, thus when this field is filled it does not mean that the record is a software one.