### PR TITLE
Normalize dois

### DIFF
--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -56,7 +56,12 @@ def update_citation_target_metadata(app, bibcode, raw_metadata, parsed_metadata)
     metadata_updated = False
     with app.session_scope() as session:
         citation_target = session.query(CitationTarget).filter(CitationTarget.parsed_cited_metadata["bibcode"].astext == bibcode).first()
-        if citation_target.raw_cited_metadata != raw_metadata.decode('utf-8') and citation_target.parsed_cited_metadata != parsed_metadata:
+        if type(raw_metadata) is not unicode:
+            try:
+                raw_metadata = raw_metadata.decode('utf-8')
+            except UnicodeEncodeError:
+                pass
+        if citation_target.raw_cited_metadata != raw_metadata and citation_target.parsed_cited_metadata != parsed_metadata:
             citation_target.raw_cited_metadata = raw_metadata
             citation_target.parsed_cited_metadata = parsed_metadata
             session.add(citation_target)

--- a/ADSCitationCapture/delta_computation.py
+++ b/ADSCitationCapture/delta_computation.py
@@ -114,13 +114,14 @@ class DeltaComputation():
                 citation_change.citing = getattr(instance, prefix+"citing")
                 resolved = getattr(instance, prefix+"resolved")
                 citation_change.cited = getattr(instance, prefix+"cited")
+                citation_change.content = getattr(instance, prefix+"content")
                 if getattr(instance, prefix+"doi"):
                     citation_change.content_type = adsmsg.CitationChangeContentType.doi
+                    citation_change.content = citation_change.content.lower() # Normalize DOI to lower case: DOI names are case insensitive (https://www.doi.org/doi_handbook/2_Numbering.html#2.4)
                 elif getattr(instance, prefix+"pid"):
                     citation_change.content_type = adsmsg.CitationChangeContentType.pid
                 elif getattr(instance, prefix+"url"):
                     citation_change.content_type = adsmsg.CitationChangeContentType.url
-                citation_change.content = getattr(instance, prefix+"content")
                 citation_change.resolved = getattr(instance, prefix+"resolved")
                 citation_change.timestamp.FromDatetime(self.last_modification_date)
                 citation_change.status = getattr(adsmsg.Status, instance.status.lower())

--- a/ADSCitationCapture/doi.py
+++ b/ADSCitationCapture/doi.py
@@ -79,7 +79,7 @@ def fetch_metadata(base_doi_url, base_datacite_url, doi):
     doi_endpoint = base_doi_url + doi
     try_later, record_found, content = _fetch_metadata(doi_endpoint, headers=headers, timeout=30)
 
-    if try_later or not record_found:
+    if try_later or not record_found or "<version/>" in content: # TODO: Temporary doi.org/crossref bug where version is not provided
         # Alternative source for metadata
         alt_doi_endpoint = base_datacite_url + doi
         alt_headers = {}


### PR DESCRIPTION
- Control decoding exceptions
- Temporary hack to avoid <version/> XML content from crossref
- Normalize DOIs to lower case to avoid duplicates