### PR TITLE
Bugfix: Avoid using non-permitted last character in bibcodes

### DIFF
--- a/ADSCitationCapture/doi.py
+++ b/ADSCitationCapture/doi.py
@@ -21,6 +21,7 @@ logger = setup_logging(__name__, proj_home=proj_home,
 
 dc = DataCiteParser()
 zenodo_doi_re = re.compile("^10.\d{4,9}/zenodo\.([0-9]*)$", re.IGNORECASE)
+upper_case_az_character_re = re.compile("[A-Z]")
 
 
 # =============================== FUNCTIONS ======================================= #
@@ -147,7 +148,11 @@ def build_bibcode(metadata, doi_re, bibstem):
         return bibcode
 
     if len(metadata.get('normalized_authors', [])) >= 1 and len(metadata['normalized_authors'][0]) >= 1:
-        first_author_last_name_initial = str(metadata['normalized_authors'][0][0])
+        first_author_last_name_initial = str(metadata['normalized_authors'][0][0]).upper()
+        if upper_case_az_character_re.fullmatch(first_author_last_name_initial) is None:
+            # If the first initial of the first author's last name is not a valid A-Z character
+            # use '.' instead respecting the bibcode convention
+            first_author_last_name_initial = "."
     else:
         logger.error("Unknown first author last name initial '%s' for DOI '%s'", ";".join(metadata.get('normalized_authors', [])), doi)
         return bibcode

--- a/ADSCitationCapture/tests/test_doi.py
+++ b/ADSCitationCapture/tests/test_doi.py
@@ -54,7 +54,6 @@ class TestWorkers(TestBase):
         self.assertEqual(decoded_content, expected_decoded_content)
 
     def test_parse_metadata(self):
-        expected_bibcode = "2007zndo.....48535G"
         datacite_xml_format_filename = os.path.join(self.app.conf['PROJ_HOME'], "ADSCitationCapture/tests/data/datacite_decoded.xml")
         with open(datacite_xml_format_filename, "r") as f:
             raw_metadata = "".join(f.readlines())
@@ -72,6 +71,12 @@ class TestWorkers(TestBase):
             parsed_metadata = json.loads("".join(f.readlines()))
         zenodo_bibstem = "zndo"
         zenodo_doi_re = re.compile("^10.\d{4,9}/zenodo\.([0-9]*)$", re.IGNORECASE)
+        bibcode = doi.build_bibcode(parsed_metadata, zenodo_doi_re, zenodo_bibstem)
+        self.assertEqual(bibcode, expected_bibcode)
+
+        expected_bibcode = "2007zndo.....48535."
+        # Add forbidden bibcode character as first initial
+        parsed_metadata['normalized_authors'][0] = "4" + parsed_metadata['normalized_authors'][0]
         bibcode = doi.build_bibcode(parsed_metadata, zenodo_doi_re, zenodo_bibstem)
         self.assertEqual(bibcode, expected_bibcode)
 


### PR DESCRIPTION
- If the first initial of the first author's last name is not a valid A-Z character use '.' instead respecting the bibcode convention