### PR TITLE
Update requirements for building of the project

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -40,7 +40,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade wheel setuptools pip
         pip install -U -r requirements.txt
         pip install -U -r dev-requirements.txt
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,3 @@ pudb==2021.1
 pytest==6.0.2
 pytest-cov==2.10.1
 pytest-pudb==0.7.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ astropy==4.2.1
 portalocker==1.7.1
 SQLAlchemy-Utils==0.37.8
 unidecode==0.04.21
+setuptools<=56


### PR DESCRIPTION
Updated requirements to avoid erroring out due to setuptools dropping support for 2to3 which adsputils (for now) needs.