### PR TITLE
Use empty string instead of None for LicenseURL field

### DIFF
--- a/ADSCitationCapture/api.py
+++ b/ADSCitationCapture/api.py
@@ -157,25 +157,25 @@ def get_github_metadata(citation_url):
     """
     Retrieve License and related metadata from GitHub API
     """
-    license_name = None
-    license_url = None
-    
+    license_name = ""
+    license_url = ""
+
     if url.is_github(citation_url):
 
         try:
             path = urllib.parse.urlparse(citation_url).path.split("/")
-            
+
         except:
             msg = "Failed to parse :{}".format(citation_url)
             logger.error(msg)
-       
+
         github_api = "https://api.github.com/repos/{}/{}/license".format(path[1],path[2])
         try:
             git_return = requests.get(github_api)
             json_return = git_return.json()
             license_name = json_return["license"]['key']
             license_url = json_return["license"]["url"]
-            
+
         except:
             msg = "Request to {} failed with status code: {}".format(github_api,git_return.status_code)
             logger.error(msg)
@@ -183,7 +183,7 @@ def get_github_metadata(citation_url):
     else:
         msg = "URL:{} is not a github repository returning default license info.".format(citation_url)
         logger.error(msg)
-        
+
     return {'license_name': license_name, 'license_url': license_url}
 
 

--- a/ADSCitationCapture/tests/test_webhook.py
+++ b/ADSCitationCapture/tests/test_webhook.py
@@ -86,9 +86,9 @@ class TestWorkers(TestBase):
         expected_target_url = "https://doi.org/{}".format(expected_target_id)
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertTrue(emitted, "Agreed citation change was NOT assigned to an agreed event")
         request = httpretty.last_request()
@@ -112,9 +112,9 @@ class TestWorkers(TestBase):
         expected_target_url = "https://doi.org/{}".format(expected_target_id)
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertTrue(emitted, "Agreed citation change was NOT assigned to an agreed event")
         request = httpretty.last_request()
@@ -132,8 +132,8 @@ class TestWorkers(TestBase):
         citation_change.status = adsmsg.Status.updated
         is_link_alive = False
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Non-agreed citation change was assigned to an agreed event")
 
@@ -155,9 +155,9 @@ class TestWorkers(TestBase):
         expected_target_url = "https://doi.org/{}".format(expected_target_id)
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Agreed citation change was NOT assigned to an agreed event")
 
@@ -228,9 +228,9 @@ class TestWorkers(TestBase):
         expected_target_url = "https://ascl.net/{}".format(expected_target_id)
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertTrue(emitted, "Agreed citation change was NOT assigned to an agreed event")
         request = httpretty.last_request()
@@ -254,9 +254,9 @@ class TestWorkers(TestBase):
         expected_target_url = "https://ascl.net/{}".format(expected_target_id)
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertTrue(emitted, "Agreed citation change was NOT assigned to an agreed event")
         request = httpretty.last_request()
@@ -274,8 +274,8 @@ class TestWorkers(TestBase):
         citation_change.status = adsmsg.Status.updated
         is_link_alive = False
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Non-agreed citation change was assigned to an agreed event")
 
@@ -298,9 +298,9 @@ class TestWorkers(TestBase):
         expected_target_url = "https://ascl.net/{}".format(expected_target_id)
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Agreed citation change was NOT assigned to an agreed event")
 
@@ -320,7 +320,10 @@ class TestWorkers(TestBase):
         expected_target_id = citation_change.content
         expected_target_id_schema = "ascl"
         expected_target_url = "https://ascl.net/{}".format(expected_target_id)
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
+        is_link_alive = True
+        license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
         event_data = webhook.citation_change_to_event_data(citation_change)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Agreed citation change was NOT assigned to an agreed event")
@@ -368,9 +371,9 @@ class TestWorkers(TestBase):
         expected_target_url = citation_change.content
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertTrue(emitted, "Agreed citation change was NOT assigned to an agreed event")
         request = httpretty.last_request()
@@ -394,9 +397,9 @@ class TestWorkers(TestBase):
         expected_target_url = citation_change.content
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertTrue(emitted, "Agreed citation change was NOT assigned to an agreed event")
         request = httpretty.last_request()
@@ -414,8 +417,8 @@ class TestWorkers(TestBase):
         citation_change.status = adsmsg.Status.updated
         is_link_alive = False
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Non-agreed citation change was assigned to an agreed event")
 
@@ -438,9 +441,9 @@ class TestWorkers(TestBase):
         expected_target_url = citation_change.content
         is_link_alive = True
         license_info = {'license_url': 'https://creativecommons.org/publicdomain/zero/1.0/'}
-        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name':license_info.get('license_name',None),'license_url':license_info.get('license_url',None) }
-        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url,parsed_metadata.get('doctype',None),parsed_metadata.get('license_url',None))
-        event_data = webhook.citation_change_to_event_data(citation_change,parsed_metadata)
+        parsed_metadata = {'link_alive': is_link_alive, "doctype": "software", 'license_name': license_info.get('license_name', ""), 'license_url': license_info.get('license_url', "") }
+        expected_json_body = self._build_expected_json_body(expected_event_type, expected_original_relationship_name, expected_source_bibcode, expected_target_id, expected_target_id_schema, expected_target_url, parsed_metadata.get('doctype', ""), parsed_metadata.get('license_url', ""))
+        event_data = webhook.citation_change_to_event_data(citation_change, parsed_metadata)
         emitted = webhook.emit_event(self.app.conf['ADS_WEBHOOK_URL'], self.app.conf['ADS_WEBHOOK_AUTH_TOKEN'], event_data, timeout=30)
         self.assertFalse(emitted, "Agreed citation change was NOT assigned to an agreed event")
 

--- a/ADSCitationCapture/webhook.py
+++ b/ADSCitationCapture/webhook.py
@@ -21,7 +21,7 @@ logger = setup_logging(__name__, proj_home=proj_home,
 
 
 # =============================== FUNCTIONS ======================================= #
-def _build_data(event_type, original_relationship_name, source_bibcode, target_id, target_id_schema, target_id_url, source_type="software",source_license="https://creativecommons.org/publicdomain/zero/1.0/"):
+def _build_data(event_type, original_relationship_name, source_bibcode, target_id, target_id_schema, target_id_url, source_type="software", source_license=""):
     now = datetime.datetime.now()
     data = {
         "RelationshipType": {
@@ -47,7 +47,7 @@ def _build_data(event_type, original_relationship_name, source_bibcode, target_i
                 "ID": target_id
             },
             "Type": {
-                "Name": source_type 
+                "Name": source_type
             }
         },
         "LinkPublicationDate": now.strftime("%Y-%m-%d"),
@@ -83,10 +83,7 @@ def _source_cites_target(citation_change, parsed_metadata, deleted=False):
     target_id, target_id_schema, target_id_url = _target_elements(citation_change)
     source_bibcode = citation_change.citing
     source_type = parsed_metadata.get('doctype', "").lower()
-    try:
-        source_license = parsed_metadata.get('license_url',"")
-    except:
-        source_license = "https://creativecommons.org/publicdomain/zero/1.0/"
+    source_license = parsed_metadata.get('license_url', "")
     data = _build_data(event_type, original_relationship_name, source_bibcode, target_id, target_id_schema, target_id_url, source_type, source_license)
     return data
 


### PR DESCRIPTION
- Asclepias broker does not like `None` values