### PR TITLE
Alembic functions

### DIFF
--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -394,6 +394,7 @@ def populate_bibcode_column(main_session):
             curated_metadata = metadata.get('curated',{})
             modified_metadata = generate_modified_metadata(parsed_metadata, curated_metadata)
             status = metadata.get('status', None)
+            #Allows for the column to be repopulated even if curated_metadata exists.
             if curated_metadata:
                 zenodo_bibstem = "zndo"
                 bibcode = doi.build_bibcode(modified_metadata, doi.zenodo_doi_re, zenodo_bibstem)

--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -2,6 +2,7 @@ import os
 from psycopg2 import IntegrityError
 from dateutil.tz import tzutc
 from ADSCitationCapture.models import Citation, CitationTarget, Event
+from ADSCitationCapture import doi
 from adsmsg import CitationChange
 from adsputils import setup_logging
 
@@ -391,7 +392,14 @@ def populate_bibcode_column(main_session):
             raw_metadata = metadata.get('raw', {})
             parsed_metadata = metadata.get('parsed', {})
             curated_metadata = metadata.get('curated',{})
+            modified_metadata = generate_modified_metadata(parsed_metadata, curated_metadata)
             status = metadata.get('status', None)
-            bibcode = parsed_metadata.get('bibcode', None)
+            if curated_metadata:
+                zenodo_bibstem = "zndo"
+                bibcode = doi.build_bibcode(modified_metadata, doi.zenodo_doi_re, zenodo_bibstem)
+                bibcode = parsed_metadata['bibcode'][:4] + bibcode[4:]
+            else:
+                bibcode = parsed_metadata.get('bibcode',None)
+
             _update_citation_target_metadata_session(main_session, content, raw_metadata, parsed_metadata, curated_metadata, status, bibcode)
 

--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -388,45 +388,20 @@ def populate_bibcode_column(main_session, curated = True):
     Pulls all citation targets from DB and populates the bibcode column using parsed metadata
     """
     logger.debug("Collecting Citation Targets")
-    records = _get_citation_targets_alembic(main_session, only_status = None)
+    records = _get_citation_targets_session(main_session, only_status = 'REGISTERED')
     for record in records:
         content = record.get('content', None)
         logger.debug("Collecting metadata for {}".format(record.get('content')))
-        metadata = _get_citation_target_metadata_alembic(main_session, content, curate = curated)
+        citation_in_db = False
+        metadata = {}
+        metadata = _get_citation_target_metadata_session(main_session, content, citation_in_db, metadata, curate=curated)
         if metadata:
             logger.debug("Updating Bibcode field for {}".format(record.get('content')))
             raw_metadata = metadata.get('raw', {})
             parsed_metadata = metadata.get('parsed', {})
             curated_metadata = metadata.get('curated',{})
             status = metadata.get('status', None)
-            _update_citation_target_metadata_alembic(main_session, content, raw_metadata, parsed_metadata, curated_metadata, status)
+            metadata_updated = False
+            if not bibcode: bibcode = parsed_metadata.get('bibcode', None)
+            _update_citation_target_metadata_session(main_session, content, raw_metadata, parsed_metadata, curated_metadata, status, bibcode)
 
-def _update_citation_target_metadata_alembic(session, content, raw_metadata, parsed_metadata, curated_metadata = {}, status=None, bibcode = None):
-    """
-    Update metadata for a citation target when we do not need to
-    close the session after completion
-    """
-    metadata_updated = False
-    if not bibcode: bibcode = parsed_metadata.get('bibcode', None)
-    metadata_updated = _update_citation_target_metadata_session(session, content, raw_metadata, parsed_metadata, curated_metadata, status, bibcode)    
-    return metadata_updated
-            
-def _get_citation_target_metadata_alembic(session, doi, curate=True):
-    """
-    If the citation target already exists in the database, return the raw and
-    parsed metadata together with the status of the citation target in the
-    database.
-    If not, return an empty dictionary. 
-    Variation for when the function does not need to control the session
-    """
-    citation_in_db = False
-    metadata = {}
-    return _get_citation_target_metadata_session(session, doi, citation_in_db, metadata, curate)
-
-def _get_citation_targets_alembic(session, only_status='REGISTERED'):
-    """
-    Return a list of dict with all citation targets (or only the registered ones)
-    - Records without a bibcode in the database will not be returned
-    Variation for then the function does not need to control the session.
-    """
-    return _get_citation_targets_session(session, only_status)

--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -74,16 +74,6 @@ def _update_citation_target_metadata_session(session, content, raw_metadata, par
     if citation_target.raw_cited_metadata != raw_metadata or citation_target.parsed_cited_metadata != parsed_metadata or \
             (status is not None and citation_target.status != status) or citation_target.curated_metadata != curated_metadata or \
         citation_target.bibcode != bibcode:
-        if citation_target.raw_cited_metadata != raw_metadata:
-            logger.debug("raw_metadata changed")
-        if citation_target.parsed_cited_metadata != parsed_metadata:
-            logger.debug("parsed_metadata changed")
-        if (status is not None and citation_target.status != status):
-            logger.debug("status changed")
-        if citation_target.curated_metadata != curated_metadata:
-            logger.debug("curated_metadata changed")
-        if citation_target.bibcode != bibcode:
-            logger.debug("bibcode changed")
         citation_target.raw_cited_metadata = raw_metadata
         citation_target.parsed_cited_metadata = parsed_metadata
         citation_target.curated_metadata = curated_metadata
@@ -383,25 +373,25 @@ def mark_all_discarded_citations_as_registered(app, content):
             session.add(citation)
         session.commit()
 
-def populate_bibcode_column(main_session, curated = True):
+def populate_bibcode_column(main_session):
     """
     Pulls all citation targets from DB and populates the bibcode column using parsed metadata
     """
     logger.debug("Collecting Citation Targets")
-    records = _get_citation_targets_session(main_session, only_status = 'REGISTERED')
+    records = _get_citation_targets_session(main_session, only_status = None)
     for record in records:
         content = record.get('content', None)
+        bibcode = record
         logger.debug("Collecting metadata for {}".format(record.get('content')))
         citation_in_db = False
         metadata = {}
-        metadata = _get_citation_target_metadata_session(main_session, content, citation_in_db, metadata, curate=curated)
+        metadata = _get_citation_target_metadata_session(main_session, content, citation_in_db, metadata, curate=False)
         if metadata:
             logger.debug("Updating Bibcode field for {}".format(record.get('content')))
             raw_metadata = metadata.get('raw', {})
             parsed_metadata = metadata.get('parsed', {})
             curated_metadata = metadata.get('curated',{})
             status = metadata.get('status', None)
-            metadata_updated = False
-            if not bibcode: bibcode = parsed_metadata.get('bibcode', None)
+            bibcode = parsed_metadata.get('bibcode', None)
             _update_citation_target_metadata_session(main_session, content, raw_metadata, parsed_metadata, curated_metadata, status, bibcode)
 

--- a/ADSCitationCapture/tasks.py
+++ b/ADSCitationCapture/tasks.py
@@ -711,11 +711,11 @@ def maintenance_show_metadata(curated_entries):
                 logger.error(msg)
 
 @app.task(queue='maintenance_metadata')
-def task_maintenance_repopulate_bibcode_columns(curated = True):
+def task_maintenance_repopulate_bibcode_columns():
     """
     Re-populates bibcode column with current canonical bibcode
     """
-    db.populate_bibcode_column(app, curated)
+    db.populate_bibcode_column(app)
 
 @app.task(queue='maintenance_resend')
 def task_maintenance_resend(dois, bibcodes, broker):

--- a/ADSCitationCapture/tasks.py
+++ b/ADSCitationCapture/tasks.py
@@ -715,7 +715,8 @@ def task_maintenance_repopulate_bibcode_columns():
     """
     Re-populates bibcode column with current canonical bibcode
     """
-    db.populate_bibcode_column(app)
+    with app.session_scope() as session:
+        db.populate_bibcode_column(session)
 
 @app.task(queue='maintenance_resend')
 def task_maintenance_resend(dois, bibcodes, broker):

--- a/alembic/versions/fae6c4a0716e_lowercase_alt_bibcodes_fix.py
+++ b/alembic/versions/fae6c4a0716e_lowercase_alt_bibcodes_fix.py
@@ -1,0 +1,60 @@
+"""lowercase_alt_bibcodes_fix
+
+Revision ID: fae6c4a0716e
+Revises: 7021071e5e63
+Create Date: 2022-05-02 15:44:20.630755
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from ADSCitationCapture import db
+
+# revision identifiers, used by Alembic.
+revision = 'fae6c4a0716e'
+down_revision = '7021071e5e63'
+branch_labels = None
+depends_on = None
+
+def correct_alternate_bibcodes(main_session, curated = False):
+    """
+    Pulls all citation targets from DB and corrects any lowercase final letters in the alternate bibcodes.
+    """
+    records = db._get_citation_targets_session(main_session, only_status = None)
+    for record in records:
+        bibcode = record.get('bibcode', None)
+        content = record.get('content', None)
+        citation_in_db = False
+        metadata = {}
+        metadata = db._get_citation_target_metadata_session(main_session, content, citation_in_db, metadata, curate=curated)
+        if metadata:
+            raw_metadata = metadata.get('raw', {})
+            parsed_metadata = metadata.get('parsed', {})
+            curated_metadata = metadata.get('curated',{})
+            status = metadata.get('status', None)
+            _update_citation_target_alt_bibcodes_alembic(main_session, content, raw_metadata, parsed_metadata, curated_metadata, status=status, bibcode=bibcode)
+
+def _update_citation_target_alt_bibcodes_alembic(session, content, raw_metadata, parsed_metadata, curated_metadata={}, status=None, bibcode=None):
+    """
+    Correct alternate bibcode format for a citation target when we do not need to
+    close the session after completion
+    """
+    metadata_updated = False
+    if not bibcode:
+        msg = "bibcode should not be None. Please check entry for {}. Skipping.".format(content)
+        return metadata_updated
+    alt_bibcodes = parsed_metadata.get('alternate_bibcode', [])
+    if alt_bibcodes:
+        #Make sure alt bibcodes have a capital final letter, and remove current bibcode form alt bibcode list
+        alt_bibcodes = [bib[:-1]+bib[-1].upper() for bib in alt_bibcodes if bib[:-1]+bib[-1].upper() != bibcode]
+        #Remove any duplicates
+        alt_bibcodes = list(set(alt_bibcodes))
+        parsed_metadata['alternate_bibcode'] = alt_bibcodes
+        metadata_updated = db._update_citation_target_metadata_session(session, content, raw_metadata, parsed_metadata, curated_metadata, status, bibcode)    
+    return metadata_updated
+
+def upgrade():
+    session = sa.orm.Session(bind=op.get_bind())    
+    correct_alternate_bibcodes(session, curated = False)
+
+def downgrade():
+   pass


### PR DESCRIPTION
Refactored populate_bibcode_column to:
- Remove alembic wrapper functions.
- Better handle being run on a db with curated_metadata.

Added alembic revision to:
- Capitalize all alt bibcodes.
- Remove the canonical bibcode from the alt bibcode list.