### PR TITLE
Fix for update_citation_target_metadata

### DIFF
--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -75,14 +75,14 @@ def _update_citation_target_metadata_session(session, content, raw_metadata, par
             pass
     if citation_target.raw_cited_metadata != raw_metadata or citation_target.parsed_cited_metadata != parsed_metadata or \
             (status is not None and citation_target.status != status) or citation_target.curated_metadata != curated_metadata or \
-        citation_target.bibcode != bibcode:
+        citation_target.bibcode != bibcode or citation_target.associated_works != associated:
         citation_target.raw_cited_metadata = raw_metadata
         citation_target.parsed_cited_metadata = parsed_metadata
         citation_target.curated_metadata = curated_metadata
         citation_target.bibcode = bibcode
         if(citation_target.associated_works != associated):
-                logger.debug("associated works set for {} set from {} to {}".format(citation_target.content, citation_target.associated_works, associated))
-                citation_target.associated_works = associated
+            logger.debug("associated works set for {} set from {} to {}".format(citation_target.content, citation_target.associated_works, associated))
+            citation_target.associated_works = associated
         if status is not None:
             citation_target.status = status
         session.add(citation_target)

--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -63,7 +63,7 @@ def store_citation_target(app, citation_change, content_type, raw_metadata, pars
             stored = True
     return stored
 
-def _update_citation_target_metadata_session(session, content, raw_metadata, parsed_metadata, curated_metadata = {}, status=None, bibcode=None, associated=None):
+def _update_citation_target_metadata_session(session, content, raw_metadata, parsed_metadata, curated_metadata={}, status=None, bibcode=None, associated=None):
     """
     Actual calls to database session for update_citation_target_metadata
     """

--- a/ADSCitationCapture/tasks.py
+++ b/ADSCitationCapture/tasks.py
@@ -270,7 +270,6 @@ def task_process_updated_associated_works(citation_change, associated_versions, 
         parsed_metadata = metadata.get('parsed', {})
         citation_target_bibcode = parsed_metadata.get('bibcode', None)
         no_self_ref_versions = {key: val for key, val in associated_versions.items() if val != citation_target_bibcode}
-        logger.info("Updating associated works for %s", citation_change.content)
         status = metadata.get('status', 'DISCARDED')
         #Forward the update only if status is "REGISTERED" and associated works is not None.
         if status == 'REGISTERED' and updated:
@@ -280,6 +279,7 @@ def task_process_updated_associated_works(citation_change, associated_versions, 
                 citations = api.get_canonical_bibcodes(app, original_citations)
                 logger.debug("Calling 'task_output_results' with '%s'", citation_change)
                 task_output_results.delay(citation_change, parsed_metadata, citations, db_versions=associated_versions)
+                logger.info("Updating associated works for %s", citation_change.content)
                 db.update_citation_target_metadata(app, citation_change.content, raw_metadata, parsed_metadata, associated=no_self_ref_versions)
         
 @app.task(queue='process-deleted-citation')

--- a/ADSCitationCapture/tests/test_tasks.py
+++ b/ADSCitationCapture/tests/test_tasks.py
@@ -1113,7 +1113,7 @@ class TestWorkers(TestBase):
             'get_citation_target_count': patch.object(db, 'get_citation_target_count', return_value=0), \
             'get_citation_count': patch.object(db, 'get_citation_count', return_value=0), \
             'get_citation_targets_by_bibcode': patch.object(db, 'get_citation_targets_by_bibcode', return_value=self.mock_data["2017zndo....248351D"]), \
-            'get_citation_targets_by_doi': patch.object(db, 'get_citation_targets_by_doi', return_value=[]), \
+            'get_citation_targets_by_doi': patch.object(db, 'get_citation_targets_by_doi', return_value=[{"bibcode":bibcode_id}]), \
             'get_citation_targets': patch.object(db, 'get_citation_targets', return_value=[]), \
             'get_canonical_bibcodes': patch.object(api, 'get_canonical_bibcodes', return_value=[]), \
             'request_existing_citations': patch.object(api, 'request_existing_citations', return_value=[]), \
@@ -1139,7 +1139,7 @@ class TestWorkers(TestBase):
         self.assertTrue(mocked['update_citation_target_metadata'].called)
         self.assertFalse(mocked['get_citation_target_count'].called)
         self.assertFalse(mocked['get_citation_count'].called)
-        self.assertFalse(mocked['get_citation_targets_by_doi'].called)
+        self.assertTrue(mocked['get_citation_targets_by_doi'].called)
         self.assertFalse(mocked['get_citation_targets'].called)
         self.assertFalse(mocked['request_existing_citations'].called)
         self.assertFalse(mocked['build_bibcode'].called)


### PR DESCRIPTION
Fix bug in `db.update_citation_target_metadata()` that stopped citation targets from being updated if the only modification is to `associated_works`.