### PR TITLE
Manual Curation Usability Updates

### DIFF
--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -101,6 +101,26 @@ def update_citation_target_metadata(app, content, raw_metadata, parsed_metadata,
         metadata_updated =  _update_citation_target_metadata_session(session, content, raw_metadata, parsed_metadata, curated_metadata, status=status, bibcode=bibcode, associated=associated)
     return metadata_updated
 
+def _update_citation_target_curator_message_session(session, content, msg):
+    """
+    Actual calls to database session for update_citation_target_metadata
+    """
+    citation_target = session.query(CitationTarget).filter(CitationTarget.content == content).first()
+    if citation_target:
+        citation_target.curated_metadata = msg
+        session.add(citation_target)
+        session.commit()
+        msg_updated = True
+        return msg_updated
+
+def update_citation_target_curator_message(app, content, msg):
+    """
+    Update metadata for a citation target
+    """
+    msg_updated = False
+    with app.session_scope() as session:
+        msg_updated =  _update_citation_target_curator_message_session(session, content, msg)
+    return msg_updated
 
 def store_citation(app, citation_change, content_type, raw_metadata, parsed_metadata, status):
     """
@@ -319,8 +339,8 @@ def generate_modified_metadata(parsed_metadata, curated_entry):
     bad_keys=[]
     if not modified_metadata.get('alternate_bibcode', None): modified_metadata.update({'alternate_bibcode':[]})
     for key in curated_entry.keys():
-        if key not in ['bibcode', 'doi']:
-            if key in modified_metadata.keys():
+        if key not in ['bibcode', 'doi', 'error']:
+            if key in modified_metadata.keys() and key:
                 try:
                     modified_metadata[key] = curated_entry[key]
                 except Exception as e:

--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -101,27 +101,6 @@ def update_citation_target_metadata(app, content, raw_metadata, parsed_metadata,
         metadata_updated =  _update_citation_target_metadata_session(session, content, raw_metadata, parsed_metadata, curated_metadata, status=status, bibcode=bibcode, associated=associated)
     return metadata_updated
 
-def _update_citation_target_curator_message_session(session, content, msg):
-    """
-    Actual calls to database session for update_citation_target_metadata
-    """
-    citation_target = session.query(CitationTarget).filter(CitationTarget.content == content).first()
-    if citation_target:
-        citation_target.curated_metadata = msg
-        session.add(citation_target)
-        session.commit()
-        msg_updated = True
-        return msg_updated
-
-def update_citation_target_curator_message(app, content, msg):
-    """
-    Update metadata for a citation target
-    """
-    msg_updated = False
-    with app.session_scope() as session:
-        msg_updated =  _update_citation_target_curator_message_session(session, content, msg)
-    return msg_updated
-
 def store_citation(app, citation_change, content_type, raw_metadata, parsed_metadata, status):
     """
     Stores a new citation in the DB

--- a/ADSCitationCapture/db.py
+++ b/ADSCitationCapture/db.py
@@ -340,7 +340,7 @@ def generate_modified_metadata(parsed_metadata, curated_entry):
     if not modified_metadata.get('alternate_bibcode', None): modified_metadata.update({'alternate_bibcode':[]})
     for key in curated_entry.keys():
         if key not in ['bibcode', 'doi', 'error']:
-            if key in modified_metadata.keys() and key:
+            if key in modified_metadata.keys():
                 try:
                     modified_metadata[key] = curated_entry[key]
                 except Exception as e:

--- a/ADSCitationCapture/doi.py
+++ b/ADSCitationCapture/doi.py
@@ -182,9 +182,13 @@ def renormalize_author_names(authors):
     to renormalize author names from curated metadata.
     """
     normalized_author_names = []
-    for name in authors:
-        norm_author_name = dc.author_names._normalize(name, collaborations_params=dc.author_collaborations_params)
-        normalized_author_names.append(norm_author_name)
+    try:
+        for name in authors:
+            norm_author_name = dc.author_names._normalize(name, collaborations_params=dc.author_collaborations_params)
+            normalized_author_names.append(norm_author_name)
+    except Exception as e:
+        logger.error("Failed to normalize author names with error: {e}")
+    
     return normalized_author_names
 
 def _parse_metadata_zenodo_doi(raw_metadata):

--- a/ADSCitationCapture/doi.py
+++ b/ADSCitationCapture/doi.py
@@ -182,13 +182,11 @@ def renormalize_author_names(authors):
     to renormalize author names from curated metadata.
     """
     normalized_author_names = []
-    try:
-        for name in authors:
-            norm_author_name = dc.author_names._normalize(name, collaborations_params=dc.author_collaborations_params)
-            normalized_author_names.append(norm_author_name)
-    except Exception as e:
-        logger.error("Failed to normalize author names with error: {e}")
-    
+
+    for name in authors:
+        norm_author_name = dc.author_names._normalize(name, collaborations_params=dc.author_collaborations_params)
+        normalized_author_names.append(norm_author_name)
+         
     return normalized_author_names
 
 def _parse_metadata_zenodo_doi(raw_metadata):

--- a/ADSCitationCapture/forward.py
+++ b/ADSCitationCapture/forward.py
@@ -97,7 +97,7 @@ def build_record(app, citation_change, parsed_metadata, citations, db_versions, 
         'database': ['general', 'astronomy'],
         'entry_date': date2solrstamp(entry_date), # date2solrstamp(get_date()),
         'year': year,
-        'date': (datetime.datetime.strptime(solr_date, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'), # TODO: Why this date has to be 30 minutes in advance? This is based on ADSImportPipeline SolrAdapter
+        'date': solr_date, # TODO: Why this date has to be 30 minutes in advance? This is based on ADSImportPipeline SolrAdapter
         'doctype': doctype,
         'doctype_facet_hier': ["0/Non-Article", "1/Non-Article/Software"],
         'doi': [doi],

--- a/ADSCitationCapture/forward.py
+++ b/ADSCitationCapture/forward.py
@@ -46,13 +46,13 @@ def build_record(app, citation_change, parsed_metadata, citations, db_versions, 
     pubdate = parsed_metadata.get('pubdate', get_date().strftime("%Y-%m-%d"))
     try:
         solr_date=(datetime.datetime.strptime(pubdate, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-    except:
+    except ValueError:
         try:
             #In the event only a year is specified, the date is assumed to be January 1st of the given year.
             logger.warn("Publication date does not conform to Y-m-d format. Assuming only year is specified.")
             pubdate = pubdate+"-01"+"-01"
             solr_date=(datetime.datetime.strptime(pubdate, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-        except:
+        except ValueError:
             #If above fails, just set it to the current date. Running maintenance_metadata could fix the bad publication date in the future if it is updated upstream.
             logger.warn("Cannot parse publication date. Setting to current datetime.")
             solr_date=date2solrstamp(entry_date)

--- a/ADSCitationCapture/forward.py
+++ b/ADSCitationCapture/forward.py
@@ -44,6 +44,19 @@ def build_record(app, citation_change, parsed_metadata, citations, db_versions, 
     normalized_authors = parsed_metadata.get('normalized_authors', [])
     affiliations = parsed_metadata.get('affiliations', ['-']*len(authors))
     pubdate = parsed_metadata.get('pubdate', get_date().strftime("%Y-%m-%d"))
+    try:
+        solr_date=(datetime.datetime.strptime(pubdate, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    except:
+        try:
+            #In the event only a year is specified, the date is assumed to be January 1st of the given year.
+            logger.warn("Publication date does not conform to Y-m-d format. Assuming only year is specified.")
+            pubdate = pubdate+"-01"+"-01"
+            solr_date=(datetime.datetime.strptime(pubdate, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        except:
+            #If above fails, just set it to the current date. Running maintenance_metadata could fix the bad publication date in the future if it is updated upstream.
+            logger.warn("Cannot parse publication date. Setting to current datetime.")
+            solr_date=date2solrstamp(entry_date)
+
     source = parsed_metadata.get('source', "Unknown")
     version = parsed_metadata.get('version', "")
     doctype = parsed_metadata.get('doctype', "software")
@@ -84,7 +97,7 @@ def build_record(app, citation_change, parsed_metadata, citations, db_versions, 
         'database': ['general', 'astronomy'],
         'entry_date': date2solrstamp(entry_date), # date2solrstamp(get_date()),
         'year': year,
-        'date': (datetime.datetime.strptime(pubdate, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'), # TODO: Why this date has to be 30 minutes in advance? This is based on ADSImportPipeline SolrAdapter
+        'date': (datetime.datetime.strptime(solr_date, "%Y-%m-%d")+datetime.timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'), # TODO: Why this date has to be 30 minutes in advance? This is based on ADSImportPipeline SolrAdapter
         'doctype': doctype,
         'doctype_facet_hier': ["0/Non-Article", "1/Non-Article/Software"],
         'doi': [doi],
@@ -129,7 +142,7 @@ def build_record(app, citation_change, parsed_metadata, citations, db_versions, 
         record_dict['status'] = status
     else:
         status = 0 # active
-    if db_versions not in [{"":""}, None]:
+    if db_versions not in [{"":""}, {}, None]:
         record_dict['property'].append('ASSOCIATED')
     if is_release:
         record_dict['property'].append('RELEASE')
@@ -160,7 +173,7 @@ def _build_nonbib_record(app, citation_change, record, db_versions, status):
         'simbad_objects': [],
         'total_link_counts': 0 # Only used for DATA and not for ESOURCES
     }
-    if db_versions not in [{"":""}, None]:
+    if db_versions not in [{"":""}, {}, None]:
         nonbib_record_dict['data_links_rows'].append({'link_type': 'ASSOCIATED', 'link_sub_type': '', 
                      'url': db_versions.values(), 'title': db_versions.keys(), 'item_count':0})
     nonbib_record = NonBibRecord(**nonbib_record_dict)

--- a/ADSCitationCapture/tasks.py
+++ b/ADSCitationCapture/tasks.py
@@ -745,10 +745,10 @@ def task_maintenance_curation(dois, bibcodes, curated_entries, reset=False):
                 logger.warn("Curated metadata did not result in a change to recorded metadata for {}.".format(registered_record.get('content')))
         except Exception as e:
             err = "task_maintenance_curation Failed to update metadata for {} with Exception: {}. Please check the input data and try again.".format(curated_entry, e)
-            err_dict = registered_record.get('curated_metadata')
+            err_dict = registered_record.get('curated_metadata', {})
             err_dict['error'] = err
             db.update_citation_target_curator_message(app, registered_record['content'], err_dict)
-            logger.error(err)
+            logger.exception(err)
             raise
 
 def maintenance_show_metadata(curated_entries):

--- a/ADSCitationCapture/tasks.py
+++ b/ADSCitationCapture/tasks.py
@@ -622,6 +622,7 @@ def task_maintenance_curation(dois, bibcodes, curated_entries, reset=False):
         try:
             if not reset:
                 if 'authors' in curated_entry.keys():
+                    #checks to make sure authors are in a list. Errors out if not.
                     if isinstance(curated_entry.get('authors', []), list):
                         curated_entry['normalized_authors'] = doi.renormalize_author_names(curated_entry.get('authors', None))
                     else:
@@ -650,11 +651,12 @@ def task_maintenance_curation(dois, bibcodes, curated_entries, reset=False):
                 parsed_metadata['alternate_bibcode'] = registered_record.get('alternate_bibcode', [])
                 #checks for provided alt bibcodes from manual curation
                 if 'alternate_bibcode' in curated_entry.keys():
+                    #checks to make sure alternate_bibcodes are in a list. Errors out if not.
                     if isinstance(curated_entry.get('alternate_bibcode', []), list):
                         alternate_bibcode = list(set(alternate_bibcode+curated_entry['alternate_bibcode']))
                         logger.debug('alternate bibcodes are {}'.format(alternate_bibcode))
                     else:
-                        logger.error("'author' key is not a list of authors. Stopping.")
+                        logger.error("'alternate_bibcodes' key is not a list of alternate_bibcodes. Stopping.")
                         err = "'alternate_bibcodes' is not a valid list of bibcodes"
                         raise TypeError(err)
 


### PR DESCRIPTION
- Added additional error handling to check for entries that should be in lists but aren't.
- Added "error" message handling to curated_metadata so errors can be returned to curators with the --show command instead of needing to look in graylog.